### PR TITLE
Fix DoItId

### DIFF
--- a/Do-It/Model/DoIts/DoItId.swift
+++ b/Do-It/Model/DoIts/DoItId.swift
@@ -9,5 +9,13 @@
 import Foundation
 
 struct DoItId: Codable {
-    private let identifier = UUID()
+    private let identifier: UUID
+
+    init() {
+        self.init(uuid: UUID())
+    }
+
+    private init(uuid: UUID) {
+        self.identifier = uuid
+    }
 }


### PR DESCRIPTION
Workaround for the way Codable works with constants defined with initial values